### PR TITLE
[codex] Add Todoist MCP label and subtask tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Project Overview
 

--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ Originally a Node.js bot; rewritten in Go (2026-04) with the MCP server merged i
 - **Auto-whitelist**: Users listed in `PROJECT_USERS_*` are automatically whitelisted — no duplicate config.
 - **Bot-admin role**: One user is admin via `BOT_ADMIN`. Only they can run `/list`.
 - **Optional due date**: `AUTO_ADD_DUE_DATE=true` → every new task gets today's date.
-- **Embedded MCP server**: `/todoist` endpoint with 7 tools, `X-API-Key` protected. Call it from `personal-assistant`, Claude Desktop, or any MCP client.
+- **Embedded MCP server**: `/todoist` endpoint with 11 tools, `X-API-Key` protected. Call it from `personal-assistant`, Claude Desktop, or any MCP client.
 - **Docker-ready**: Single static binary (~11 MB), alpine image, GitHub Actions builds & pushes to GHCR.
 
 ## Why Go?
@@ -135,15 +135,19 @@ All 10+ Telegram attachment types are rendered as clickable Markdown:
 
 The `/todoist` endpoint uses `mcp-go`'s Streamable HTTP transport and is protected by `X-API-Key`.
 
-**7 tools exposed:**
+**11 tools exposed:**
 
 | Tool | Purpose |
 |---|---|
 | `get_projects` | List all Todoist projects |
 | `get_labels` | List all labels |
-| `get_tasks` | List tasks (optional `project_id`, `filter`, `limit`) |
-| `create_task` | Create a task (`content` required; optional `description`, `project_id`, `due_string`/`due_date`, `priority`, `labels`) |
-| `update_task` | Update an existing task (`task_id` required) |
+| `create_label` | Create a personal label (`name` required; optional `color`, `order`, `is_favorite`) |
+| `update_label` | Update a personal label (`label_id` required) |
+| `delete_label` | Delete a personal label and remove it from tasks |
+| `get_tasks` | List tasks (optional `project_id`, `section_id`, `parent_id`, `label`, `filter`, `limit`) |
+| `create_task` | Create a task (`content` required; optional `description`, `project_id`, `section_id`, `parent_id`, `due_string`/`due_date`, `priority`, `labels`) |
+| `update_task` | Update an existing task (`task_id` required; optional `content`, `description`, `due_string`/`due_date`, `priority`, `labels`) |
+| `move_task` | Move a task to another project, section, or parent (`task_id` required) |
 | `delete_task` | Delete a task |
 | `complete_task` | Mark a task complete |
 
@@ -301,7 +305,7 @@ Go-сервис, который делает две вещи в одном пр�
 - **Автоматический вайтлист**: Пользователи из `PROJECT_USERS_*` автоматически добавляются в whitelist — без дубля конфига.
 - **Роль админа**: Один пользователь — админ через `BOT_ADMIN`. Только он может вызывать `/list`.
 - **Опциональная дата выполнения**: `AUTO_ADD_DUE_DATE=true` → каждая новая задача получает срок на сегодня.
-- **Встроенный MCP-сервер**: Эндпоинт `/todoist` с 7 инструментами, защищён `X-API-Key`. Подключается из `personal-assistant`, Claude Desktop или любого MCP-клиента.
+- **Встроенный MCP-сервер**: Эндпоинт `/todoist` с 11 инструментами, защищён `X-API-Key`. Подключается из `personal-assistant`, Claude Desktop или любого MCP-клиента.
 - **Docker-ready**: Один статический бинарник (~11 МБ), alpine-образ, GitHub Actions пушат в GHCR.
 
 ## Почему Go?
@@ -387,15 +391,19 @@ Go-сервис, который делает две вещи в одном пр�
 
 Эндпоинт `/todoist` использует Streamable HTTP транспорт из `mcp-go` и защищён `X-API-Key`.
 
-**Экспонируются 7 инструментов:**
+**Экспонируются 11 инструментов:**
 
 | Инструмент | Назначение |
 |---|---|
 | `get_projects` | Список всех проектов Todoist |
 | `get_labels` | Список всех меток |
-| `get_tasks` | Список задач (опционально `project_id`, `filter`, `limit`) |
-| `create_task` | Создать задачу (`content` обязателен; опционально `description`, `project_id`, `due_string`/`due_date`, `priority`, `labels`) |
-| `update_task` | Обновить существующую задачу (`task_id` обязателен) |
+| `create_label` | Создать персональную метку (`name` обязателен; опционально `color`, `order`, `is_favorite`) |
+| `update_label` | Обновить персональную метку (`label_id` обязателен) |
+| `delete_label` | Удалить персональную метку и снять её с задач |
+| `get_tasks` | Список задач (опционально `project_id`, `section_id`, `parent_id`, `label`, `filter`, `limit`) |
+| `create_task` | Создать задачу (`content` обязателен; опционально `description`, `project_id`, `section_id`, `parent_id`, `due_string`/`due_date`, `priority`, `labels`) |
+| `update_task` | Обновить существующую задачу (`task_id` обязателен; опционально `content`, `description`, `due_string`/`due_date`, `priority`, `labels`) |
+| `move_task` | Переместить задачу в другой проект, секцию или под родителя (`task_id` обязателен) |
 | `delete_task` | Удалить задачу |
 | `complete_task` | Завершить задачу |
 

--- a/docs/ai-plans/2026-05-28-todoist-mcp-labels-subtasks.html
+++ b/docs/ai-plans/2026-05-28-todoist-mcp-labels-subtasks.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <title>Implementation Plan: Todoist MCP Labels and Subtasks</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f6f7f9;
+      color: #1f2937;
+      line-height: 1.5;
+    }
+    main { max-width: 1080px; margin: 0 auto; padding: 32px; }
+    section {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 20px;
+      margin: 16px 0;
+    }
+    h1, h2, h3 { line-height: 1.2; margin-top: 0; }
+    h1 { margin-bottom: 8px; }
+    code { background: #f3f4f6; padding: 2px 5px; border-radius: 4px; }
+    ul, ol { padding-left: 24px; }
+    li { margin: 6px 0; }
+    table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+    th, td { border: 1px solid #e5e7eb; padding: 8px 10px; text-align: left; vertical-align: top; }
+    th { background: #f9fafb; }
+    .badge {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: #fef3c7;
+      color: #92400e;
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .note { border-left: 4px solid #2563eb; }
+    .risk { border-left: 4px solid #dc2626; }
+    .approval { border-left: 4px solid #d97706; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Implementation Plan: Todoist MCP Labels and Subtasks</h1>
+  <p class="badge">Approval required before implementation</p>
+
+  <section>
+    <h2>Task Summary</h2>
+    <p>
+      Extend the Todoist MCP server in this Go service so MCP clients can create, update, and delete Todoist labels,
+      explicitly assign labels through the MCP tool schemas, and work with subtasks by listing, creating, and moving
+      tasks under or out from a parent task.
+    </p>
+  </section>
+
+  <section>
+    <h2>Current Behavior</h2>
+    <ul>
+      <li><code>internal/todoist/server.go</code> registers 7 tools: projects, labels list, tasks list, task create/update/delete/complete.</li>
+      <li><code>create_task</code> and <code>update_task</code> already copy a raw <code>labels</code> argument into the Todoist payload, but the schema does not declare that argument.</li>
+      <li><code>get_tasks</code> supports <code>project_id</code>, <code>filter</code>, and <code>limit</code>, but not <code>section_id</code>, <code>parent_id</code>, or label filtering.</li>
+      <li><code>internal/todoist/client.go</code> has raw wrappers for <code>/projects</code>, <code>/labels</code>, and <code>/tasks</code>, but no label mutation methods and no task move method.</li>
+      <li>Telegram-side task creation already supports labels parsed from <code>#tag</code> and should remain unchanged unless implementation discovers a shared helper is useful.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Desired Behavior</h2>
+    <table>
+      <thead>
+        <tr><th>Area</th><th>Proposed MCP surface</th><th>Todoist API behavior</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Label CRUD</td>
+          <td>Add <code>create_label</code>, <code>update_label</code>, <code>delete_label</code>. Keep <code>get_labels</code>.</td>
+          <td>Use <code>POST /labels</code>, <code>POST /labels/{label_id}</code>, and <code>DELETE /labels/{label_id}</code>.</td>
+        </tr>
+        <tr>
+          <td>Task labels</td>
+          <td>Declare <code>labels</code> as an array input on <code>create_task</code> and <code>update_task</code>.</td>
+          <td>Pass Todoist label names in the existing task payload field <code>labels</code>.</td>
+        </tr>
+        <tr>
+          <td>Create subtasks</td>
+          <td>Add optional <code>parent_id</code> to <code>create_task</code>; optionally allow <code>section_id</code> as adjacent placement support.</td>
+          <td>Todoist task creation supports a parent task identifier for creating a subtask.</td>
+        </tr>
+        <tr>
+          <td>List subtasks</td>
+          <td>Add <code>parent_id</code>, <code>section_id</code>, and <code>label</code> filters to <code>get_tasks</code>.</td>
+          <td>Todoist <code>GET /tasks</code> supports these query parameters.</td>
+        </tr>
+        <tr>
+          <td>Move subtasks</td>
+          <td>Add <code>move_task</code> with <code>task_id</code> required and optional <code>project_id</code>, <code>section_id</code>, <code>parent_id</code>.</td>
+          <td>Use <code>POST /tasks/{task_id}/move</code>; <code>parent_id: null</code> should be supported if MCP argument handling can represent it cleanly.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Assumptions and Unknowns</h2>
+    <ul>
+      <li>Todoist API v1 remains the target because <code>defaultBaseURL</code> is <code>https://api.todoist.com/api/v1</code> and docs in this repo already name REST API v1.</li>
+      <li>Personal labels are in scope. Shared label rename/remove endpoints are not included unless explicitly requested.</li>
+      <li>Deletion of a label removes it from tasks in Todoist. The MCP should expose that clearly but not add custom cascade logic.</li>
+      <li>For moving a task back to top level, we need to verify how <code>mcp-go</code> exposes explicit JSON <code>null</code> versus omitted fields in tool arguments.</li>
+      <li>No database access is needed; this feature is an HTTP API wrapper over Todoist.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Files Likely to Change</h2>
+    <ul>
+      <li><code>internal/todoist/client.go</code> - add raw client methods for label mutation, richer task listing, and task move.</li>
+      <li><code>internal/todoist/server.go</code> - register new MCP tools and argument handling helpers, including array and boolean parameters.</li>
+      <li><code>internal/todoist/client_test.go</code> - cover new HTTP methods, paths, query parameters, and JSON payloads.</li>
+      <li><code>internal/todoist/server_test.go</code> - likely new focused tests for MCP argument mapping and required-field validation.</li>
+      <li><code>README.md</code>, <code>Readme.md</code>, <code>AGENTS.md</code>, <code>CLAUDE.md</code> - update documented tool count and capability list after implementation.</li>
+      <li><code>docs/ai-plans/2026-05-28-todoist-mcp-labels-subtasks.html</code> - update after implementation with actual changes and checks.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Implementation Steps</h2>
+    <ol>
+      <li>Add client methods: <code>CreateLabel</code>, <code>UpdateLabel</code>, <code>DeleteLabel</code>, <code>MoveTask</code>, and an expanded task-list query builder.</li>
+      <li>Add MCP tools for label CRUD with required-field checks: <code>name</code> for create, <code>label_id</code> for update/delete, and at least one mutable field for update.</li>
+      <li>Declare <code>labels</code> in <code>create_task</code> and <code>update_task</code> schemas, and normalize arguments to <code>[]string</code> where possible before forwarding.</li>
+      <li>Add <code>parent_id</code> and <code>section_id</code> support to <code>create_task</code>; add <code>parent_id</code>, <code>section_id</code>, and <code>label</code> support to <code>get_tasks</code>.</li>
+      <li>Add <code>move_task</code> to move an existing task to another project, section, or parent. Reject empty moves where no destination field is provided.</li>
+      <li>Update documentation in English and Russian sections to list the new tools and subtask semantics.</li>
+      <li>Run formatting and verification; update this plan with the results before reporting completion.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>API, Auth, and Deployment Impact</h2>
+    <ul>
+      <li>API contract changes: MCP clients will see additional tools and richer schemas for existing tools.</li>
+      <li>Auth does not change. All new tools stay behind the existing <code>X-API-Key</code> middleware on <code>/todoist</code>.</li>
+      <li>Deployment does not require new environment variables or migrations.</li>
+      <li>Backward compatibility should hold for existing clients because current tool names and existing arguments remain valid.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Test Plan</h2>
+    <ul>
+      <li><code>go test ./...</code> for all unit tests.</li>
+      <li><code>go vet ./...</code> for static checks.</li>
+      <li><code>go build ./...</code> to confirm the service still compiles as a deployable binary.</li>
+      <li>Unit tests should assert paths such as <code>/labels</code>, <code>/labels/{label_id}</code>, <code>/tasks?parent_id=...</code>, and <code>/tasks/{task_id}/move</code>.</li>
+      <li>Manual live Todoist API smoke test is optional and should only run if explicitly approved because it mutates real Todoist data.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Manual QA Checklist</h2>
+    <ul>
+      <li>Start the service locally with test Todoist credentials and <code>API_KEY</code>.</li>
+      <li>Call <code>get_labels</code>, then <code>create_label</code>, <code>update_label</code>, and <code>delete_label</code> against a disposable label.</li>
+      <li>Create a parent task, create a subtask with <code>parent_id</code>, list it with <code>get_tasks parent_id=...</code>, then delete the test task tree.</li>
+      <li>Move a disposable task under a parent with <code>move_task</code>, then move it back or delete it.</li>
+      <li>Confirm Telegram bot behavior for normal message-to-task creation is unchanged.</li>
+    </ul>
+  </section>
+
+  <section class="risk">
+    <h2>Risks and Edge Cases</h2>
+    <ul>
+      <li>Todoist label deletion is destructive for task label assignments. The tool should be plainly named and documented.</li>
+      <li>MCP array argument handling may deliver <code>labels</code> as <code>[]interface{}</code>, <code>[]string</code>, or another decoded shape depending on client; normalize conservatively.</li>
+      <li>Explicit <code>null</code> support for removing a parent or section may need a separate boolean such as <code>clear_parent</code> if MCP client schemas cannot distinguish omitted from null.</li>
+      <li>Todoist IDs are now string-like in v1 examples; keep all IDs as strings in Go and MCP schemas.</li>
+      <li>Existing docs currently say 7 tools; all copies must be updated together to avoid drift.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Rollback Plan</h2>
+    <p>
+      Revert the MCP/client/documentation changes as one commit or patch. Because this plan does not introduce migrations,
+      environment variables, or persisted local state, rollback is a normal code rollback plus redeploy of the previous image.
+    </p>
+  </section>
+
+  <section>
+    <h2>Open Questions</h2>
+    <ul>
+      <li>Should shared-label operations (<code>shared labels rename/remove</code>) be included now, or keep scope to personal labels?</li>
+      <li>Do you want a single generic <code>manage_label</code> tool with an <code>action</code> enum, or separate MCP tools? I recommend separate tools for clearer schemas and safer destructive operations.</li>
+      <li>Should <code>move_task</code> include explicit <code>clear_parent</code> / <code>clear_section</code> booleans if direct <code>null</code> is awkward from clients?</li>
+    </ul>
+  </section>
+
+  <section class="note">
+    <h2>Implementation Result</h2>
+    <ul>
+      <li>Added Todoist client methods for <code>create/update/delete label</code>, richer task listing, and <code>move_task</code>.</li>
+      <li>Registered 4 new MCP tools: <code>create_label</code>, <code>update_label</code>, <code>delete_label</code>, and <code>move_task</code>.</li>
+      <li>Expanded existing MCP schemas: <code>get_tasks</code> now exposes <code>section_id</code>, <code>parent_id</code>, and <code>label</code>; <code>create_task</code> exposes <code>section_id</code>, <code>parent_id</code>, and <code>labels</code>; <code>update_task</code> exposes <code>labels</code>.</li>
+      <li>Implemented <code>clear_parent</code> and <code>clear_section</code> booleans on <code>move_task</code> to send explicit JSON <code>null</code> without relying on MCP clients to pass null fields.</li>
+      <li>Updated README-style documentation to report 11 MCP tools and describe label/subtask support.</li>
+      <li>Added unit coverage for label endpoints, task structural filters, move endpoint payloads, MCP label/subtask argument mapping, and validation errors.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Verification Results</h2>
+    <ul>
+      <li><code>gofmt</code> completed for changed Go files.</li>
+      <li><code>go test ./...</code> passed.</li>
+      <li><code>go vet ./...</code> passed.</li>
+      <li><code>go build ./...</code> passed.</li>
+      <li>No live Todoist smoke test was run because it would mutate real Todoist data.</li>
+    </ul>
+  </section>
+
+  <section class="approval">
+    <h2>Approval Gate</h2>
+    <p>
+      Approved by the user with "погнал" on 2026-05-28. Implementation is complete and verified locally.
+    </p>
+  </section>
+</main>
+</body>
+</html>

--- a/internal/todoist/client.go
+++ b/internal/todoist/client.go
@@ -101,12 +101,53 @@ func (c *Client) GetLabels(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, "/labels", nil)
 }
 
+func (c *Client) CreateLabel(ctx context.Context, label map[string]interface{}) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/labels", label)
+}
+
+func (c *Client) UpdateLabel(ctx context.Context, labelID string, update map[string]interface{}) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/labels/"+labelID, update)
+}
+
+func (c *Client) DeleteLabel(ctx context.Context, labelID string) error {
+	_, err := c.do(ctx, http.MethodDelete, "/labels/"+labelID, nil)
+	return err
+}
+
+type TaskListOptions struct {
+	ProjectID string
+	SectionID string
+	ParentID  string
+	Label     string
+	Limit     int
+}
+
 func (c *Client) GetTasks(ctx context.Context, projectID string, limit int) ([]byte, error) {
-	path := fmt.Sprintf("/tasks?limit=%d", limit)
-	if projectID != "" {
-		path += "&project_id=" + url.QueryEscape(projectID)
+	return c.GetTasksWithOptions(ctx, TaskListOptions{
+		ProjectID: projectID,
+		Limit:     limit,
+	})
+}
+
+func (c *Client) GetTasksWithOptions(ctx context.Context, opts TaskListOptions) ([]byte, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 20
 	}
-	return c.do(ctx, http.MethodGet, path, nil)
+	values := url.Values{}
+	values.Set("limit", fmt.Sprintf("%d", opts.Limit))
+	if opts.ProjectID != "" {
+		values.Set("project_id", opts.ProjectID)
+	}
+	if opts.SectionID != "" {
+		values.Set("section_id", opts.SectionID)
+	}
+	if opts.ParentID != "" {
+		values.Set("parent_id", opts.ParentID)
+	}
+	if opts.Label != "" {
+		values.Set("label", opts.Label)
+	}
+	return c.do(ctx, http.MethodGet, "/tasks?"+values.Encode(), nil)
 }
 
 func (c *Client) GetTasksFiltered(ctx context.Context, filter string, limit int) ([]byte, error) {
@@ -120,6 +161,10 @@ func (c *Client) CreateTask(ctx context.Context, task map[string]interface{}) ([
 
 func (c *Client) UpdateTask(ctx context.Context, taskID string, update map[string]interface{}) ([]byte, error) {
 	return c.do(ctx, http.MethodPost, "/tasks/"+taskID, update)
+}
+
+func (c *Client) MoveTask(ctx context.Context, taskID string, move map[string]interface{}) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/tasks/"+taskID+"/move", move)
 }
 
 func (c *Client) DeleteTask(ctx context.Context, taskID string) error {

--- a/internal/todoist/client_test.go
+++ b/internal/todoist/client_test.go
@@ -53,6 +53,38 @@ func TestClient_ListTasks_IncludesProjectFilter(t *testing.T) {
 	}
 }
 
+func TestClient_GetTasksWithOptions_IncludesStructuralFilters(t *testing.T) {
+	var gotQuery string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tasks" {
+			t.Errorf("path: %q", r.URL.Path)
+		}
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	})
+	_, err := c.GetTasksWithOptions(context.Background(), TaskListOptions{
+		ProjectID: "project 1",
+		SectionID: "section 1",
+		ParentID:  "parent 1",
+		Label:     "health",
+		Limit:     7,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"project_id=project+1",
+		"section_id=section+1",
+		"parent_id=parent+1",
+		"label=health",
+		"limit=7",
+	} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
 func TestClient_CreateTask_SendsJSON(t *testing.T) {
 	var gotBody string
 	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -72,6 +104,71 @@ func TestClient_CreateTask_SendsJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if parsed["content"] != "hi" || parsed["priority"].(float64) != 2 {
+		t.Errorf("payload: %v", parsed)
+	}
+}
+
+func TestClient_CreateLabel_SendsJSON(t *testing.T) {
+	var gotBody string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/labels" {
+			t.Errorf("request: %s %s", r.Method, r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		_, _ = w.Write([]byte(`{"id":"label1","name":"health"}`))
+	})
+	payload := map[string]interface{}{"name": "health", "color": "berry_red", "is_favorite": true}
+	if _, err := c.CreateLabel(context.Background(), payload); err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(gotBody), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["name"] != "health" || parsed["color"] != "berry_red" || parsed["is_favorite"] != true {
+		t.Errorf("payload: %v", parsed)
+	}
+}
+
+func TestClient_UpdateAndDeleteLabel_UseLabelIDPath(t *testing.T) {
+	var requests []string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		if r.Method == http.MethodPost {
+			_, _ = w.Write([]byte(`{"id":"label1","name":"health"}`))
+		}
+	})
+	if _, err := c.UpdateLabel(context.Background(), "label1", map[string]interface{}{"name": "health"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.DeleteLabel(context.Background(), "label1"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"POST /labels/label1", "DELETE /labels/label1"}
+	if strings.Join(requests, ",") != strings.Join(want, ",") {
+		t.Errorf("requests: got %v, want %v", requests, want)
+	}
+}
+
+func TestClient_MoveTask_UsesMoveEndpoint(t *testing.T) {
+	var gotBody string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tasks/task1/move" {
+			t.Errorf("request: %s %s", r.Method, r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		_, _ = w.Write([]byte(`{"id":"task1"}`))
+	})
+	if _, err := c.MoveTask(context.Background(), "task1", map[string]interface{}{"parent_id": "parent1"}); err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(gotBody), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["parent_id"] != "parent1" {
 		t.Errorf("payload: %v", parsed)
 	}
 }

--- a/internal/todoist/server.go
+++ b/internal/todoist/server.go
@@ -26,9 +26,34 @@ func (s *MCPServer) RegisterTools(srv *server.MCPServer) {
 		mcp.WithDescription("List all Todoist labels."),
 	), s.getLabels)
 
+	srv.AddTool(mcp.NewTool("create_label",
+		mcp.WithDescription("Create a Todoist personal label."),
+		mcp.WithString("name", mcp.Description("Label name"), mcp.Required()),
+		mcp.WithString("color", mcp.Description("Todoist label color name or ID")),
+		mcp.WithNumber("order", mcp.Description("Label order in the label list")),
+		mcp.WithBoolean("is_favorite", mcp.Description("Whether the label is marked as favorite")),
+	), s.createLabel)
+
+	srv.AddTool(mcp.NewTool("update_label",
+		mcp.WithDescription("Update a Todoist personal label."),
+		mcp.WithString("label_id", mcp.Description("Label ID"), mcp.Required()),
+		mcp.WithString("name", mcp.Description("New label name")),
+		mcp.WithString("color", mcp.Description("New Todoist label color name or ID")),
+		mcp.WithNumber("order", mcp.Description("New label order")),
+		mcp.WithBoolean("is_favorite", mcp.Description("Whether the label is marked as favorite")),
+	), s.updateLabel)
+
+	srv.AddTool(mcp.NewTool("delete_label",
+		mcp.WithDescription("Delete a Todoist personal label and remove it from tasks."),
+		mcp.WithString("label_id", mcp.Description("Label ID"), mcp.Required()),
+	), s.deleteLabel)
+
 	srv.AddTool(mcp.NewTool("get_tasks",
 		mcp.WithDescription("Get tasks, optionally filtered by project or Todoist filter query."),
 		mcp.WithString("project_id", mcp.Description("Filter by project ID")),
+		mcp.WithString("section_id", mcp.Description("Filter by section ID")),
+		mcp.WithString("parent_id", mcp.Description("Filter by parent task ID to list subtasks")),
+		mcp.WithString("label", mcp.Description("Filter by label name")),
 		mcp.WithString("filter", mcp.Description("Todoist filter query (e.g. 'today', 'overdue', '#Work')")),
 		mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
 	), s.getTasks)
@@ -38,9 +63,12 @@ func (s *MCPServer) RegisterTools(srv *server.MCPServer) {
 		mcp.WithString("content", mcp.Description("Task title"), mcp.Required()),
 		mcp.WithString("description", mcp.Description("Task description / notes")),
 		mcp.WithString("project_id", mcp.Description("Project to add task to")),
+		mcp.WithString("section_id", mcp.Description("Section to add task to")),
+		mcp.WithString("parent_id", mcp.Description("Parent task ID for creating a subtask")),
 		mcp.WithString("due_string", mcp.Description("Natural language due date (e.g. 'tomorrow')")),
 		mcp.WithString("due_date", mcp.Description("Absolute due date YYYY-MM-DD")),
 		mcp.WithNumber("priority", mcp.Description("1 (normal) to 4 (urgent)")),
+		mcp.WithArray("labels", mcp.Description("Todoist label names"), mcp.WithStringItems()),
 	), s.createTask)
 
 	srv.AddTool(mcp.NewTool("update_task",
@@ -51,7 +79,18 @@ func (s *MCPServer) RegisterTools(srv *server.MCPServer) {
 		mcp.WithString("due_string", mcp.Description("New due date (natural language)")),
 		mcp.WithString("due_date", mcp.Description("New absolute due date YYYY-MM-DD")),
 		mcp.WithNumber("priority", mcp.Description("New priority (1-4)")),
+		mcp.WithArray("labels", mcp.Description("Todoist label names"), mcp.WithStringItems()),
 	), s.updateTask)
+
+	srv.AddTool(mcp.NewTool("move_task",
+		mcp.WithDescription("Move a Todoist task to another project, section, or parent task."),
+		mcp.WithString("task_id", mcp.Description("Task ID"), mcp.Required()),
+		mcp.WithString("project_id", mcp.Description("Destination project ID")),
+		mcp.WithString("section_id", mcp.Description("Destination section ID")),
+		mcp.WithString("parent_id", mcp.Description("Destination parent task ID")),
+		mcp.WithBoolean("clear_section", mcp.Description("Move the task out of its current section")),
+		mcp.WithBoolean("clear_parent", mcp.Description("Move the task out from under its parent task")),
+	), s.moveTask)
 
 	srv.AddTool(mcp.NewTool("delete_task",
 		mcp.WithDescription("Delete a Todoist task."),
@@ -80,9 +119,59 @@ func (s *MCPServer) getLabels(ctx context.Context, _ mcp.CallToolRequest) (*mcp.
 	return mcp.NewToolResultText(formatJSON(data)), nil
 }
 
+func (s *MCPServer) createLabel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	name := strParam(args, "name")
+	if name == "" {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+
+	label := map[string]interface{}{"name": name}
+	addStringFields(label, args, "color")
+	addRawFields(label, args, "order", "is_favorite")
+
+	data, err := s.client.CreateLabel(ctx, label)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	return mcp.NewToolResultText(formatJSON(data)), nil
+}
+
+func (s *MCPServer) updateLabel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	labelID := strParam(args, "label_id")
+	if labelID == "" {
+		return mcp.NewToolResultError("label_id is required"), nil
+	}
+
+	update := map[string]interface{}{}
+	addStringFields(update, args, "name", "color")
+	addRawFields(update, args, "order", "is_favorite")
+	if len(update) == 0 {
+		return mcp.NewToolResultError("at least one label field is required"), nil
+	}
+
+	data, err := s.client.UpdateLabel(ctx, labelID, update)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	return mcp.NewToolResultText(formatJSON(data)), nil
+}
+
+func (s *MCPServer) deleteLabel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	labelID := strParam(args, "label_id")
+	if labelID == "" {
+		return mcp.NewToolResultError("label_id is required"), nil
+	}
+	if err := s.client.DeleteLabel(ctx, labelID); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("Deleted label %s", labelID)), nil
+}
+
 func (s *MCPServer) getTasks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
-	projectID := strParam(args, "project_id")
 	filter := strParam(args, "filter")
 	limit := intParam(args, "limit", 20)
 
@@ -91,7 +180,13 @@ func (s *MCPServer) getTasks(ctx context.Context, req mcp.CallToolRequest) (*mcp
 	if filter != "" {
 		data, err = s.client.GetTasksFiltered(ctx, filter, limit)
 	} else {
-		data, err = s.client.GetTasks(ctx, projectID, limit)
+		data, err = s.client.GetTasksWithOptions(ctx, TaskListOptions{
+			ProjectID: strParam(args, "project_id"),
+			SectionID: strParam(args, "section_id"),
+			ParentID:  strParam(args, "parent_id"),
+			Label:     strParam(args, "label"),
+			Limit:     limit,
+		})
 	}
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -107,16 +202,12 @@ func (s *MCPServer) createTask(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 
 	task := map[string]interface{}{"content": content}
-	for _, key := range []string{"description", "project_id", "due_string", "due_date"} {
-		if v := strParam(args, key); v != "" {
-			task[key] = v
-		}
-	}
+	addStringFields(task, args, "description", "project_id", "section_id", "parent_id", "due_string", "due_date")
 	if v, ok := args["priority"]; ok && v != nil {
 		task["priority"] = v
 	}
-	if v, ok := args["labels"]; ok && v != nil {
-		task["labels"] = v
+	if labels, ok := stringSliceParam(args, "labels"); ok {
+		task["labels"] = labels
 	}
 
 	data, err := s.client.CreateTask(ctx, task)
@@ -134,19 +225,47 @@ func (s *MCPServer) updateTask(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 
 	update := map[string]interface{}{}
-	for _, key := range []string{"content", "description", "due_string", "due_date"} {
-		if v := strParam(args, key); v != "" {
-			update[key] = v
-		}
-	}
+	addStringFields(update, args, "content", "description", "due_string", "due_date")
 	if v, ok := args["priority"]; ok && v != nil {
 		update["priority"] = v
 	}
-	if v, ok := args["labels"]; ok && v != nil {
-		update["labels"] = v
+	if labels, ok := stringSliceParam(args, "labels"); ok {
+		update["labels"] = labels
 	}
 
 	data, err := s.client.UpdateTask(ctx, taskID, update)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	return mcp.NewToolResultText(formatJSON(data)), nil
+}
+
+func (s *MCPServer) moveTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	taskID := strParam(args, "task_id")
+	if taskID == "" {
+		return mcp.NewToolResultError("task_id is required"), nil
+	}
+	if strParam(args, "parent_id") != "" && boolParam(args, "clear_parent") {
+		return mcp.NewToolResultError("parent_id and clear_parent cannot both be set"), nil
+	}
+	if strParam(args, "section_id") != "" && boolParam(args, "clear_section") {
+		return mcp.NewToolResultError("section_id and clear_section cannot both be set"), nil
+	}
+
+	move := map[string]interface{}{}
+	addStringFields(move, args, "project_id", "section_id", "parent_id")
+	if boolParam(args, "clear_parent") {
+		move["parent_id"] = nil
+	}
+	if boolParam(args, "clear_section") {
+		move["section_id"] = nil
+	}
+	if len(move) == 0 {
+		return mcp.NewToolResultError("at least one destination field is required"), nil
+	}
+
+	data, err := s.client.MoveTask(ctx, taskID, move)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -188,6 +307,26 @@ func strParam(args map[string]interface{}, key string) string {
 	return s
 }
 
+func stringSliceParam(args map[string]interface{}, key string) ([]string, bool) {
+	v, ok := args[key]
+	if !ok || v == nil {
+		return nil, false
+	}
+	switch labels := v.(type) {
+	case []string:
+		return labels, true
+	case []interface{}:
+		out := make([]string, 0, len(labels))
+		for _, label := range labels {
+			if s, ok := label.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
 func intParam(args map[string]interface{}, key string, def int) int {
 	v, ok := args[key]
 	if !ok || v == nil {
@@ -200,6 +339,31 @@ func intParam(args map[string]interface{}, key string, def int) int {
 		return n
 	}
 	return def
+}
+
+func boolParam(args map[string]interface{}, key string) bool {
+	v, ok := args[key]
+	if !ok || v == nil {
+		return false
+	}
+	b, _ := v.(bool)
+	return b
+}
+
+func addStringFields(dst map[string]interface{}, args map[string]interface{}, keys ...string) {
+	for _, key := range keys {
+		if v := strParam(args, key); v != "" {
+			dst[key] = v
+		}
+	}
+}
+
+func addRawFields(dst map[string]interface{}, args map[string]interface{}, keys ...string) {
+	for _, key := range keys {
+		if v, ok := args[key]; ok && v != nil {
+			dst[key] = v
+		}
+	}
 }
 
 func formatJSON(data []byte) string {

--- a/internal/todoist/server_test.go
+++ b/internal/todoist/server_test.go
@@ -1,0 +1,151 @@
+package todoist
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func callToolRequest(args map[string]any) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: args,
+		},
+	}
+}
+
+func TestMCPServer_CreateTask_MapsLabelsAndParent(t *testing.T) {
+	var gotBody map[string]any
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tasks" {
+			t.Errorf("request: %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"id":"task1"}`))
+	})
+
+	srv := NewMCPServer(client)
+	result, err := srv.createTask(context.Background(), callToolRequest(map[string]any{
+		"content":   "child",
+		"parent_id": "parent1",
+		"labels":    []any{"health", "todoist-bot"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %+v", result)
+	}
+	if gotBody["content"] != "child" || gotBody["parent_id"] != "parent1" {
+		t.Errorf("payload: %v", gotBody)
+	}
+	labels, ok := gotBody["labels"].([]any)
+	if !ok || len(labels) != 2 || labels[0] != "health" || labels[1] != "todoist-bot" {
+		t.Errorf("labels: %v", gotBody["labels"])
+	}
+}
+
+func TestMCPServer_UpdateLabel_RequiresMutableField(t *testing.T) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected HTTP request")
+	})
+	srv := NewMCPServer(client)
+
+	result, err := srv.updateLabel(context.Background(), callToolRequest(map[string]any{
+		"label_id": "label1",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error, got %+v", result)
+	}
+}
+
+func TestMCPServer_UpdateTask_AllowsClearingLabels(t *testing.T) {
+	var gotBody map[string]any
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tasks/task1" {
+			t.Errorf("request: %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"id":"task1"}`))
+	})
+
+	srv := NewMCPServer(client)
+	result, err := srv.updateTask(context.Background(), callToolRequest(map[string]any{
+		"task_id": "task1",
+		"labels":  []any{},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %+v", result)
+	}
+	labels, ok := gotBody["labels"].([]any)
+	if !ok || len(labels) != 0 {
+		t.Errorf("labels: %v", gotBody["labels"])
+	}
+}
+
+func TestMCPServer_MoveTask_ClearsParent(t *testing.T) {
+	var gotBody map[string]any
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tasks/task1/move" {
+			t.Errorf("request: %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"id":"task1"}`))
+	})
+
+	srv := NewMCPServer(client)
+	result, err := srv.moveTask(context.Background(), callToolRequest(map[string]any{
+		"task_id":      "task1",
+		"clear_parent": true,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %+v", result)
+	}
+	if _, ok := gotBody["parent_id"]; !ok {
+		t.Fatalf("parent_id missing from payload: %v", gotBody)
+	}
+	if gotBody["parent_id"] != nil {
+		t.Errorf("parent_id: got %v, want nil", gotBody["parent_id"])
+	}
+}
+
+func TestMCPServer_MoveTask_RejectsConflictingParentArgs(t *testing.T) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected HTTP request")
+	})
+	srv := NewMCPServer(client)
+
+	result, err := srv.moveTask(context.Background(), callToolRequest(map[string]any{
+		"task_id":      "task1",
+		"parent_id":    "parent1",
+		"clear_parent": true,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error, got %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary
- add MCP tools for creating, updating, and deleting Todoist labels
- expose subtask support through parent_id filters, task creation, and move_task
- document the expanded 11-tool MCP surface and include the approved implementation plan

## Validation
- go test ./...
- go vet ./...
- go build ./...